### PR TITLE
Create target folders before copying javadoc and code coverage

### DIFF
--- a/.github/workflows/main-push.yml
+++ b/.github/workflows/main-push.yml
@@ -64,8 +64,10 @@ jobs:
       - name: Copy Code Coverage and Source Documentation
         run: |
           rm -rf gh-pages/docs/javadoc/
+          mkdir -p gh-pages/docs/javadoc/
           cp -r main-project/build/docs/javadoc/* gh-pages/docs/javadoc/
           rm -rf gh-pages/docs/jacoco/
+          mkdir -p gh-pages/docs/javadoc/
           cp -r main-project/build/reports/jacoco/test/* gh-pages/docs/jacoco/
 
       - name: Commit and Push gh-pages


### PR DESCRIPTION
Create target folders before copying javadoc and code coverage