### PR TITLE
Fixes #38, Only create channel threads if a subscriber is interested.

### DIFF
--- a/metalog-api/src/main/java/io/github/jonloucks/metalog/api/MainDispatcher.java
+++ b/metalog-api/src/main/java/io/github/jonloucks/metalog/api/MainDispatcher.java
@@ -1,0 +1,25 @@
+package io.github.jonloucks.metalog.api;
+
+import io.github.jonloucks.contracts.api.Contract;
+
+/**
+ * Responsibility: Create delegate dispatchers on demand and discard them when no longer needed
+ */
+public interface MainDispatcher extends Dispatcher {
+    /**
+     * The Contract for the main dispatcher
+     */
+    Contract<MainDispatcher> CONTRACT = Contract.create(MainDispatcher.class);
+    
+    /**
+     * Uses the Subscriber to determine which dispatchers are required
+     * @param subscriber the subscriber
+     */
+    void registerSubscriber(Subscriber subscriber);
+    
+    /**
+     * Used the Subscriber to determine which dispatchers are no longer needed
+     * @param subscriber the subscriber
+     */
+    void unregisterSubscriber(Subscriber subscriber);
+}

--- a/metalog-api/src/main/java/io/github/jonloucks/metalog/api/Metalog.java
+++ b/metalog-api/src/main/java/io/github/jonloucks/metalog/api/Metalog.java
@@ -104,6 +104,10 @@ public interface Metalog extends Publisher, Filterable, AutoOpen {
             return Duration.ofSeconds(60);
         }
         
+        default boolean keyedSubscription() {
+            return false;
+        }
+        
         interface Builder extends Config {
             Contract<Supplier<Builder>> FACTORY = Contract.create("Metalog Config Builder Factory");
             
@@ -116,6 +120,7 @@ public interface Metalog extends Publisher, Filterable, AutoOpen {
             Builder shutdownTimeout(Duration shutdownTimeout);
             Builder reflectionClassName(String reflectionClassName);
             Builder serviceLoaderClass(Class<? extends MetalogFactory> serviceLoaderClass);
+            Builder keyedSubscription(boolean keyedSubscription);
         }
     }
 }

--- a/metalog-api/src/main/java/io/github/jonloucks/metalog/api/Subscriber.java
+++ b/metalog-api/src/main/java/io/github/jonloucks/metalog/api/Subscriber.java
@@ -1,5 +1,6 @@
 package io.github.jonloucks.metalog.api;
 
+import java.util.Optional;
 import java.util.function.Predicate;
 
 /**
@@ -25,5 +26,12 @@ public interface Subscriber extends Predicate<Meta> {
     @Override
     default boolean test(Meta meta) {
         return true;
+    }
+    
+    /**
+     * @return the optional key
+     */
+    default Optional<String> getKey() {
+        return Optional.empty();
     }
 }

--- a/metalog-impl/src/main/java/io/github/jonloucks/metalog/impl/ConfigBuilderImpl.java
+++ b/metalog-impl/src/main/java/io/github/jonloucks/metalog/impl/ConfigBuilderImpl.java
@@ -65,6 +65,12 @@ final class ConfigBuilderImpl implements Metalog.Config.Builder {
     }
     
     @Override
+    public Builder keyedSubscription(boolean keyedSubscription) {
+        this.keyedSubscription = keyedSubscription;
+        return this;
+    }
+    
+    @Override
     public boolean useReflection() {
         return useReflection;
     }
@@ -108,6 +114,11 @@ final class ConfigBuilderImpl implements Metalog.Config.Builder {
     public Duration shutdownTimeout() {
         return shutdownTimeout;
     }
+    
+    @Override
+    public boolean keyedSubscription() {
+        return keyedSubscription;
+    }
  
     ConfigBuilderImpl() {
     
@@ -122,4 +133,5 @@ final class ConfigBuilderImpl implements Metalog.Config.Builder {
     private Duration shutdownTimeout = DEFAULT.shutdownTimeout();
     private String reflectionClassName = DEFAULT.reflectionClassName();
     private Class<? extends MetalogFactory> serviceLoaderClass = DEFAULT.serviceLoaderClass();
+    private boolean keyedSubscription = DEFAULT.keyedSubscription();
 }

--- a/metalog-impl/src/main/java/io/github/jonloucks/metalog/impl/ConsoleImpl.java
+++ b/metalog-impl/src/main/java/io/github/jonloucks/metalog/impl/ConsoleImpl.java
@@ -7,9 +7,7 @@ import io.github.jonloucks.contracts.api.AutoOpen;
 import io.github.jonloucks.metalog.api.*;
 
 import java.io.PrintStream;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -71,6 +69,11 @@ final class ConsoleImpl implements Console, AutoOpen {
             return getPrintStream(validMeta).map(toPrint(validLog, validMeta)).orElse(Outcome.SKIPPED);
         }
         return Outcome.SKIPPED;
+    }
+    
+    @Override
+    public Optional<String> getKey() {
+        return Optional.of(CONSOLE_KEY);
     }
     
     private static Function<PrintStream, Outcome> toPrint(Log log, Meta meta) {

--- a/metalog-impl/src/main/java/io/github/jonloucks/metalog/impl/Internal.java
+++ b/metalog-impl/src/main/java/io/github/jonloucks/metalog/impl/Internal.java
@@ -2,10 +2,13 @@ package io.github.jonloucks.metalog.impl;
 
 import io.github.jonloucks.metalog.api.*;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import static io.github.jonloucks.contracts.api.Checks.nameCheck;
 import static io.github.jonloucks.contracts.api.Checks.nullCheck;
+import static java.lang.ThreadLocal.withInitial;
 
 final class Internal {
     
@@ -51,6 +54,10 @@ final class Internal {
         return nullCheck(subscriber, "Subscribers must be present.");
     }
     
+    static String keyCheck(String key) {
+        return nullCheck(key, "Key must be present.");
+    }
+    
     static Predicate<Entity> byName(String name) {
         final String validName = nameCheck(name);
         
@@ -71,4 +78,24 @@ final class Internal {
         
         }
     }
+    
+    @SuppressWarnings("UnusedReturnValue")
+    static Outcome guardedDelivery(Subscriber subscriber, Log log, Meta meta) {
+        final Map<String, Object> context = THREAD_CONTEXT.get();
+        final Meta previousMeta = (Meta)context.put(META_PROPERTY, meta);
+        final Subscriber previousSubscriber = (Subscriber) context.put(SUBSCRIBER_PROPERTY, subscriber);
+        try {
+            if (previousSubscriber == subscriber) {
+                return Outcome.REJECTED;
+            }
+            return subscriber.receive(log, meta);
+        } finally {
+            context.put(META_PROPERTY, previousMeta);
+            context.put(SUBSCRIBER_PROPERTY, previousSubscriber);
+        }
+    }
+    
+    private static final ThreadLocal<Map<String, Object>> THREAD_CONTEXT = withInitial(LinkedHashMap::new);
+    private static final String META_PROPERTY = "meta";
+    private static final String SUBSCRIBER_PROPERTY = "subscriber";
 }

--- a/metalog-impl/src/main/java/io/github/jonloucks/metalog/impl/MainDispatcherImpl.java
+++ b/metalog-impl/src/main/java/io/github/jonloucks/metalog/impl/MainDispatcherImpl.java
@@ -1,0 +1,127 @@
+package io.github.jonloucks.metalog.impl;
+
+import io.github.jonloucks.contracts.api.AutoClose;
+import io.github.jonloucks.contracts.api.Contract;
+import io.github.jonloucks.contracts.api.Repository;
+import io.github.jonloucks.metalog.api.*;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import static io.github.jonloucks.contracts.api.GlobalContracts.lifeCycle;
+import static io.github.jonloucks.metalog.impl.Internal.*;
+import static java.util.Optional.ofNullable;
+
+final class MainDispatcherImpl implements MainDispatcher {
+
+    @Override
+    public Outcome dispatch(Meta meta, Runnable job) {
+        final Optional<Dispatcher> foundDispatcher = findDispatcher(meta);
+        if (foundDispatcher.isPresent()) {
+            return foundDispatcher.get().dispatch(meta, job);
+        }
+        return Outcome.SKIPPED;
+    }
+    
+    @Override
+    public AutoClose open() {
+        return AutoClose.NONE;
+    }
+    
+    @Override
+    public void registerSubscriber(Subscriber subscriber) {
+        if (config.keyedSubscription()) {
+            final Subscriber validSubscriber = subscriberCheck(subscriber);
+            final String key = validSubscriber.getKey().orElse("");
+            incrementKeyUsage(key);
+        }
+    }
+    
+    @Override
+    public void unregisterSubscriber(Subscriber subscriber) {
+        if (config.keyedSubscription()) {
+            final Subscriber validSubscriber = subscriberCheck(subscriber);
+            final String key = validSubscriber.getKey().orElse("");
+            decrementKeyUsage(key);
+        }
+    }
+    
+    MainDispatcherImpl(Metalog.Config config, Repository repository) {
+        this.config = config;
+        this.repository = repository;
+    }
+    
+    private Optional<Dispatcher> findDispatcher(Meta meta) {
+        final Meta validMeta = metaCheck(meta);
+        final String key = validMeta.getKey().orElse("");
+        if (config.keyedSubscription()) {
+            return ofNullable(keySmartMap.get(key)).flatMap(Smart::get);
+        } else {
+            return keySmartMap.computeIfAbsent(key, k -> {
+                final Smart smart = new Smart(k);
+                smart.incrementUsage();
+                return smart;
+            }).get();
+        }
+    }
+    
+    private void incrementKeyUsage(String key) {
+        keySmartMap.computeIfAbsent(keyCheck(key), Smart::new).incrementUsage();
+    }
+    
+    private void decrementKeyUsage(String key) {
+        ofNullable(keySmartMap.get(keyCheck(key))).ifPresent(Smart::decrementUsage);
+    }
+    
+    private Supplier<Dispatcher> getDispatcherFactory(String key) {
+        return config.contracts().claim(key.isEmpty() ? UNKEYED_FACTORY : KEYED_FACTORY);
+    }
+    
+    private final class Smart {
+        Smart(String key) {
+            this.key = key;
+            this.contract = Contract.create(Dispatcher.class, n -> n.name("Dispatcher " + key));
+        }
+        
+        Optional<Dispatcher> get() {
+            final Optional<Dispatcher> optionalDispatcher = ofNullable(dispatcher);
+            if (optionalDispatcher.isPresent()) {
+                return optionalDispatcher;
+            }
+            return acquire();
+        }
+        
+        private synchronized Optional<Dispatcher> acquire() {
+            final Optional<Dispatcher> optionalDispatcher = ofNullable(dispatcher);
+            if (optionalDispatcher.isPresent()) {
+                return optionalDispatcher;
+            }
+            closeBinding = repository.store(contract, lifeCycle(getDispatcherFactory(key)::get));
+            dispatcher = config.contracts().claim(contract);
+            
+            return Optional.of(dispatcher);
+        }
+        
+        synchronized void incrementUsage() {
+            ++usageCount;
+        }
+        
+        synchronized void decrementUsage() {
+            if (--usageCount == 0) {
+                ofNullable(closeBinding).ifPresent(AutoClose::close);
+                keySmartMap.remove(key, this);
+            }
+        }
+        
+        private final String key;
+        private final Contract<Dispatcher> contract;
+        private volatile Dispatcher dispatcher;
+        private int usageCount = 0;
+        private AutoClose closeBinding;
+    }
+    
+    private final Metalog.Config config;
+    private final Repository repository;
+    private final ConcurrentHashMap<String, Smart> keySmartMap = new ConcurrentHashMap<>();
+}

--- a/metalog-impl/src/main/java/io/github/jonloucks/metalog/impl/MetalogFactoryImpl.java
+++ b/metalog-impl/src/main/java/io/github/jonloucks/metalog/impl/MetalogFactoryImpl.java
@@ -93,14 +93,17 @@ public final class MetalogFactoryImpl implements MetalogFactory {
         repository.require(WaitableFactory.CONTRACT);
         repository.require(StateMachineFactory.CONTRACT);
         
-        repository.keep(Metalog.Config.Builder.FACTORY, () -> ConfigBuilderImpl::new, IF_NOT_BOUND);
-        repository.keep(Entities.Builder.FACTORY, () -> EntitiesImpl::new, IF_NOT_BOUND);
-        repository.keep(Entity.Builder.FACTORY, () -> EntityImpl::new, IF_NOT_BOUND);
-        repository.keep(Meta.Builder.FACTORY, () -> MetaImpl::new, IF_NOT_BOUND);
+        final BindStrategy strategy = IF_NOT_BOUND;
         
-        repository.keep(MetalogFactory.CONTRACT, lifeCycle(MetalogFactoryImpl::new), IF_NOT_BOUND);
-        repository.keep(Dispatcher.KEYED_FACTORY, () -> () -> new KeyedDispatcherImpl(config), IF_NOT_BOUND);
-        repository.keep(Dispatcher.UNKEYED_FACTORY, () -> ()-> new UnkeyedDispatcherImpl(config), IF_NOT_BOUND);
-        repository.keep(Console.CONTRACT, lifeCycle(() -> new ConsoleImpl(config)), IF_NOT_BOUND);
+        repository.keep(Metalog.Config.Builder.FACTORY, () -> ConfigBuilderImpl::new, strategy);
+        repository.keep(Entities.Builder.FACTORY, () -> EntitiesImpl::new, strategy);
+        repository.keep(Entity.Builder.FACTORY, () -> EntityImpl::new, strategy);
+        repository.keep(Meta.Builder.FACTORY, () -> MetaImpl::new, strategy);
+        
+        repository.keep(MetalogFactory.CONTRACT, lifeCycle(MetalogFactoryImpl::new), strategy);
+        repository.keep(Dispatcher.KEYED_FACTORY, () -> () -> new KeyedDispatcherImpl(config), strategy);
+        repository.keep(Dispatcher.UNKEYED_FACTORY, () -> ()-> new UnkeyedDispatcherImpl(config), strategy);
+        repository.keep(MainDispatcher.CONTRACT, lifeCycle(() -> new MainDispatcherImpl(config, repository)), strategy);
+        repository.keep(Console.CONTRACT, lifeCycle(() -> new ConsoleImpl(config)), strategy);
     }
 }

--- a/metalog-impl/src/main/java/io/github/jonloucks/metalog/impl/MetalogImpl.java
+++ b/metalog-impl/src/main/java/io/github/jonloucks/metalog/impl/MetalogImpl.java
@@ -5,21 +5,18 @@ import io.github.jonloucks.concurrency.api.StateMachine;
 import io.github.jonloucks.contracts.api.*;
 import io.github.jonloucks.metalog.api.*;
 
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import static io.github.jonloucks.concurrency.api.Idempotent.withClose;
 import static io.github.jonloucks.concurrency.api.Idempotent.withOpen;
 import static io.github.jonloucks.contracts.api.Checks.*;
-import static io.github.jonloucks.contracts.api.GlobalContracts.lifeCycle;
 import static io.github.jonloucks.metalog.impl.Internal.*;
-import static java.lang.ThreadLocal.withInitial;
 
 final class MetalogImpl implements Metalog {
     
@@ -36,7 +33,7 @@ final class MetalogImpl implements Metalog {
             if (shouldTransmitNow(validMeta)) {
                 return transmitNow(validLog, validMeta);
             } else {
-                return relayToDispatcher(validMeta, validLog);
+                return transmitLater(validMeta, validLog);
             }
         } else {
             return Outcome.SKIPPED;
@@ -57,44 +54,51 @@ final class MetalogImpl implements Metalog {
     
     @Override
     public boolean test(Meta meta) {
-        return filters.test(meta) && subscribers.stream().anyMatch(s -> s.test(meta));
+        final Meta validMeta = metaCheck(meta);
+        return filters.test(validMeta) && subscribers.stream().anyMatch(matcher(validMeta));
     }
     
     @Override
     public AutoClose subscribe(Subscriber subscriber) {
         final Subscriber validSubscriber = subscriberCheck(subscriber);
         subscribers.add(validSubscriber);
-        return () -> subscribers.removeIf( x -> x == validSubscriber);
+        mainDispatcher.registerSubscriber(validSubscriber);
+        return () -> removeSubscriber(validSubscriber);
     }
-
+    
     @Override
     public AutoClose open() {
         return withOpen(stateMachine, this::realOpen);
     }
     
     MetalogImpl(Config config, Repository repository, boolean openRepository) {
+        final Repository validRepository = nullCheck(repository, "Repository must be present.");
         this.config = configCheck(config);
-        this.repository = nullCheck(repository, "Repository must be present.");
-        this.closeRepository = openRepository ? repository.open() : AutoClose.NONE;
+        this.closeRepository = openRepository ? validRepository.open() : AutoClose.NONE;
         this.stateMachine = Idempotent.createStateMachine(config.contracts());
     }
     
     private AutoClose realOpen() {
         metaFactory = config.contracts().claim(Meta.Builder.FACTORY);
-        keyedDispatcherFactory = config.contracts().claim(Dispatcher.KEYED_FACTORY);
-        unkeyedDispatcherFactory = config.contracts().claim(Dispatcher.UNKEYED_FACTORY);
-        createUnkeyedDispatcher();
+        this.mainDispatcher = config.contracts().claim(MainDispatcher.CONTRACT);
         activateConsole();
         return this::close;
     }
-
-    private void createUnkeyedDispatcher() {
-        final Contracts contracts = config.contracts();
-        final Contract<Dispatcher> contract = Contract.create(Dispatcher.class, n -> n.name("Unkeyed Dispatcher"));
-        repository.keep(contract, lifeCycle(unkeyedDispatcherFactory::get));
-        dispatchers.put(UNKEYED, contracts.claim(contract));
-    }
     
+    private Predicate<Subscriber> matcher(Meta meta) {
+        if (config.keyedSubscription()) {
+            final Optional<String> optionalKey = meta.getKey();
+            if (optionalKey.isPresent()) {
+                final String key = optionalKey.get();
+                return s -> s.getKey().isPresent() && key.equals(s.getKey().get()) && s.test(meta);
+            } else {
+                return s -> !s.getKey().isPresent() && s.test(meta);
+            }
+        } else {
+            return s -> s.test(meta); // legacy, subscriptions can receive any log
+        }
+    }
+
     private void activateConsole() {
         config.contracts().claim(Console.CONTRACT);
     }
@@ -106,73 +110,41 @@ final class MetalogImpl implements Metalog {
     private void realClose() {
         closeRepository.close();
     }
-    
+
     private boolean shouldTransmitNow(Meta meta) {
-        return meta.isBlocking() || onDispatchingThread();
+        return meta.isBlocking();
     }
     
-    private Outcome relayToDispatcher(Meta meta, Log log) {
-        final Dispatcher dispatcher = chooseDispatcher(meta);
+    private Outcome transmitLater(Meta meta, Log log) {
+        return forSubscriber(meta, s -> mainDispatcher.dispatch(meta, ()-> guardedDelivery(s, log, meta)));
+    }
+    
+    private Outcome forSubscriber(Meta meta, Function<Subscriber,Outcome> consumer) {
         final AtomicReference<Outcome> outcomeReference = new AtomicReference<>(Outcome.SKIPPED);
-        
-        subscribers.forEach(subscriber -> {
-            if (subscriber.test(meta)) {
-                outcomeReference.set(relayWithContext(subscriber, dispatcher, meta, log));
+        subscribers.stream().filter(matcher(meta)).forEach( subscriber -> {
+            final Outcome outcome = consumer.apply(subscriber);
+            if (outcome != Outcome.SKIPPED) {
+                outcomeReference.set(outcome);
             }
         });
-        
         return outcomeReference.get();
-    }
-    
-    private Outcome relayWithContext(Subscriber subscriber, Dispatcher dispatcher, Meta meta, Log log) {
-        return dispatcher.dispatch(meta,  () -> {
-            final Map<String,Object> context = THREAD_CONTEXT.get();
-            final Object oldValue = context.put(DISPATCHING_PROPERTY, true);
-            try {
-                subscriber.receive(log, meta);
-            } finally {
-                context.put(DISPATCHING_PROPERTY, oldValue);
-            }
-        });
-    }
-    
-    private boolean onDispatchingThread() {
-        return Boolean.TRUE.equals(THREAD_CONTEXT.get().get(DISPATCHING_PROPERTY));
-    }
-    
-    private Dispatcher chooseDispatcher(Meta meta) {
-        final String key = meta.getKey().orElse("");
-        return dispatchers.computeIfAbsent(key, this::createKeyedDispatcher);
-    }
-    
-    private Dispatcher createKeyedDispatcher(String key) {
-        final Contract<Dispatcher> contract = Contract.create(Dispatcher.class, n -> n.name("Keyed Dispatcher " + key));
-        repository.keep(contract, lifeCycle(keyedDispatcherFactory::get));
-        return config.contracts().claim(contract);
     }
     
     private Outcome transmitNow(Log log, Meta meta) {
-        final AtomicReference<Outcome> outcomeReference = new AtomicReference<>(Outcome.SKIPPED);
-        subscribers.forEach(subscriber -> {
-            if (subscriber.test(meta)) {
-                outcomeReference.set(subscriber.receive(log, meta));
-            }
-        });
-        return outcomeReference.get();
+        return forSubscriber(meta, s -> guardedDelivery(s, log, meta));
     }
     
-    private static final ThreadLocal<Map<String, Object>> THREAD_CONTEXT = withInitial(LinkedHashMap::new);
-    private static final String DISPATCHING_PROPERTY = "dispatching";
-    private static final String UNKEYED = "";
+    private void removeSubscriber(Subscriber subscriber) {
+        if (subscribers.removeIf( x -> x == subscriber)) {
+            mainDispatcher.unregisterSubscriber(subscriber);
+        }
+    }
     
     private final Config config;
     private final StateMachine<Idempotent> stateMachine;
-    private final Repository repository;
     private final AutoClose closeRepository;
     private final List<Subscriber> subscribers = new CopyOnWriteArrayList<>();
     private final Filterable filters = new FiltersImpl();
-    private final ConcurrentHashMap<String,Dispatcher> dispatchers = new ConcurrentHashMap<>();
+    private MainDispatcher mainDispatcher;
     private Supplier<Meta.Builder<?>> metaFactory;
-    private Supplier<Dispatcher> keyedDispatcherFactory;
-    private Supplier<Dispatcher> unkeyedDispatcherFactory;
 }

--- a/metalog-impl/src/main/java/module-info.java
+++ b/metalog-impl/src/main/java/module-info.java
@@ -5,6 +5,7 @@ module io.github.jonloucks.metalog.impl {
     requires transitive io.github.jonloucks.contracts.api;
     requires transitive io.github.jonloucks.concurrency.api;
     requires transitive io.github.jonloucks.metalog.api;
+    requires jdk.compiler;
     
     exports io.github.jonloucks.metalog.impl;
     

--- a/metalog-test/src/main/java/io/github/jonloucks/metalog/test/ConsoleTests.java
+++ b/metalog-test/src/main/java/io/github/jonloucks/metalog/test/ConsoleTests.java
@@ -51,6 +51,17 @@ public interface ConsoleTests {
     }
     
     @Test
+    default void console_publish_WithLogAndNoNewLine_Works() {
+        withMetalog((contracts, metalog) -> {
+            final Console console = contracts.claim(Console.CONTRACT);
+            
+            final Outcome outcome = console.publish(() -> "Hello", b -> b.newLine(false));
+            
+            assertOutcomeSuccess(outcome);
+        });
+    }
+    
+    @Test
     default void console_publish_WithLog_Works() {
         withMetalog((contracts, metalog) -> {
             final Console console = contracts.claim(Console.CONTRACT);
@@ -127,7 +138,7 @@ public interface ConsoleTests {
             consoleRef.set(contracts.claim(Console.CONTRACT));
         });
         
-        assertNotNull(consoleRef.get().publish(() -> "Hello"));
+        assertNotNull(consoleRef.get().publish(() -> "Hello", b -> b.channel(channel)));
     }
     
     @ParameterizedTest(name = "channel = {0}")

--- a/metalog-test/src/main/java/io/github/jonloucks/metalog/test/KeyedSubscriptionTests.java
+++ b/metalog-test/src/main/java/io/github/jonloucks/metalog/test/KeyedSubscriptionTests.java
@@ -1,0 +1,149 @@
+package io.github.jonloucks.metalog.test;
+
+import io.github.jonloucks.contracts.api.AutoClose;
+import io.github.jonloucks.metalog.api.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Optional;
+
+import static io.github.jonloucks.contracts.test.Tools.ignore;
+import static io.github.jonloucks.metalog.api.Outcome.*;
+import static io.github.jonloucks.metalog.test.Tools.withMetalog;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public interface KeyedSubscriptionTests {
+    
+    @Test
+    default void keyedSubscription_SubscriberWithKey_WhenMetaHasDifferentKey_IsSkipped(@Mock Subscriber subscriber) {
+        when(subscriber.test(any())).thenReturn(true);
+        when(subscriber.getKey()).thenReturn(Optional.of("green"));
+        withMetalog(b -> b.keyedSubscription(true), (contracts, metalog) -> {
+            try (AutoClose closeSubscription = metalog.subscribe(subscriber)) {
+                ignore(closeSubscription);
+                final Outcome outcome = metalog.publish(() -> "x", b -> b.key("blue"));
+                assertEquals(SKIPPED, outcome);
+            }
+        });
+    }
+    
+    @Test
+    default void keyedSubscription_SubscriberWithNoKey_WhenMetaHasNoKey_IsConsumed(@Mock Subscriber subscriber) {
+        when(subscriber.test(any())).thenReturn(true);
+        when(subscriber.getKey()).thenReturn(Optional.empty());
+        when(subscriber.receive(any(),any())).thenReturn(Outcome.CONSUMED);
+        withMetalog(b -> b.keyedSubscription(true), (contracts, metalog) -> {
+            try (AutoClose closeSubscription = metalog.subscribe(subscriber)) {
+                ignore(closeSubscription);
+                final Outcome outcome = metalog.publish(() -> "x", b -> {});
+                assertEquals(DISPATCHED, outcome);
+            }
+        });
+    }
+    
+    @Test
+    default void keyedSubscription_SubscriberWithNoKey_WhenMetaHasNoKey_ButFilterFails_IsSkipped(@Mock Subscriber subscriber) {
+        when(subscriber.test(any())).thenReturn(true);
+        when(subscriber.getKey()).thenReturn(Optional.empty());
+        withMetalog(b -> b.keyedSubscription(true), (contracts, metalog) -> {
+            try (AutoClose closeSubscription = metalog.subscribe(subscriber);
+                 AutoClose closeFilter = metalog.addFilter(m -> false)) {
+                ignore(closeSubscription); ignore(closeFilter);
+                final Outcome outcome = metalog.publish(() -> "x", b -> {});
+                assertEquals(SKIPPED, outcome);
+            }
+        });
+    }
+    
+    @Test
+    default void keyedSubscription_SubscriberWithNoKey_WhenMetaHasNoKey_ButTestFails_IsSkipped(@Mock Subscriber subscriber) {
+        when(subscriber.test(any())).thenReturn(false);
+        when(subscriber.getKey()).thenReturn(Optional.empty());
+        withMetalog(b -> b.keyedSubscription(true), (contracts, metalog) -> {
+            try (AutoClose closeSubscription = metalog.subscribe(subscriber)) {
+                ignore(closeSubscription);
+                final Outcome outcome = metalog.publish(() -> "x", b -> {});
+                assertEquals(SKIPPED, outcome);
+            }
+        });
+    }
+    
+    @Test
+    default void keyedSubscription_SubscriberWithKey_WhenMetaHasSameKey_IsConsumed(@Mock Subscriber subscriber) {
+        when(subscriber.test(any())).thenReturn(true);
+        when(subscriber.getKey()).thenReturn(Optional.of("green"));
+        when(subscriber.receive(any(),any())).thenReturn(Outcome.CONSUMED);
+        withMetalog(b -> b.keyedSubscription(true), (contracts, metalog) -> {
+            try (AutoClose closeSubscription = metalog.subscribe(subscriber)) {
+                ignore(closeSubscription);
+                final Outcome outcome = metalog.publish(() -> "x", b -> b.key("green"));
+                assertEquals(DISPATCHED, outcome);
+            }
+        });
+    }
+    
+    @Test
+    default void keyedSubscription_SubscriberWithKey_WhenMetaHasSameKey_ButTestFails_IsSkipped(@Mock Subscriber subscriber) {
+        when(subscriber.test(any())).thenReturn(false);
+        when(subscriber.getKey()).thenReturn(Optional.of("green"));
+        withMetalog(b -> b.keyedSubscription(true), (contracts, metalog) -> {
+            try (AutoClose closeSubscription = metalog.subscribe(subscriber)) {
+                ignore(closeSubscription);
+                final Outcome outcome = metalog.publish(() -> "x", b -> b.key("green"));
+                assertEquals(SKIPPED, outcome);
+            }
+        });
+    }
+    
+    @Test
+    default void keyedSubscription_SubscriberWithKey_WhenMetaHasNoKey_IsSkipped(@Mock Subscriber subscriber) {
+        when(subscriber.test(any())).thenReturn(true);
+        when(subscriber.getKey()).thenReturn(Optional.of("green"));
+        withMetalog(b -> b.keyedSubscription(true), (contracts, metalog) -> {
+            try (AutoClose closeSubscription = metalog.subscribe(subscriber)) {
+                ignore(closeSubscription);
+                final Outcome outcome = metalog.publish(() -> "x", b -> {});
+                assertEquals(SKIPPED, outcome);
+            }
+        });
+    }
+    
+    @Test
+    default void keyedSubscription_SubscriberWithOutKey_WhenMetaHasKey_IsSkipped(@Mock Subscriber subscriber) {
+        when(subscriber.test(any())).thenReturn(true);
+        when(subscriber.getKey()).thenReturn(Optional.empty());
+        withMetalog(b -> b.keyedSubscription(true), (contracts, metalog) -> {
+            try (AutoClose closeSubscription = metalog.subscribe(subscriber)) {
+                ignore(closeSubscription);
+                final Outcome outcome = metalog.publish(() -> "x", b -> b.key("green"));
+                assertEquals(SKIPPED, outcome);
+            }
+        });
+    }
+    
+    @Test
+    default void keyedSubscription_TwoSubscribersWithKey_WithOneSkipped_Works(@Mock Subscriber subscriber1,@Mock Subscriber subscriber2) {
+        when(subscriber1.test(any())).thenReturn(true);
+        when(subscriber1.getKey()).thenReturn(Optional.of("green"));
+        when(subscriber1.receive(any(),any())).thenReturn(CONSUMED);
+        
+        when(subscriber2.test(any())).thenReturn(true);
+        when(subscriber2.getKey()).thenReturn(Optional.of("green"));
+        when(subscriber2.receive(any(),any())).thenReturn(SKIPPED);
+        withMetalog(b -> b.keyedSubscription(true), (contracts, metalog) -> {
+            try (AutoClose closeSubscription1 = metalog.subscribe(subscriber1);
+                 AutoClose closeSubscription2 = metalog.subscribe(subscriber2)) {
+                ignore(closeSubscription1); ignore(closeSubscription2);
+                final Outcome outcome = metalog.publish(() -> "x", b -> b.key("green"));
+                assertEquals(DISPATCHED, outcome);
+            }
+        });
+    }
+}

--- a/metalog-test/src/main/java/io/github/jonloucks/metalog/test/MetaTests.java
+++ b/metalog-test/src/main/java/io/github/jonloucks/metalog/test/MetaTests.java
@@ -44,15 +44,22 @@ public interface MetaTests {
             
             fromBuilder
                 .text(textSupplier)
+                .id(null)
                 .id("id1")
+                .name(null)
                 .name("name1")
+                .value(null)
                 .value("value1")
                 .channel("channel1")
+                .key(null)
                 .key("sequenceKey1")
                 .block()
+                .thread(null)
                 .thread(thread)
+                .thrown(null)
                 .thrown(thrown)
                 .unique(true)
+                .time(null)
                 .time(timestamp);
             
             metaBuilder.copy(fromBuilder);

--- a/metalog-test/src/main/java/io/github/jonloucks/metalog/test/MetalogConfigTests.java
+++ b/metalog-test/src/main/java/io/github/jonloucks/metalog/test/MetalogConfigTests.java
@@ -25,6 +25,7 @@ public interface MetalogConfigTests {
             assertEquals(DEFAULT.unkeyedThreadCount(), builder.unkeyedThreadCount());
             assertEquals(DEFAULT.reflectionClassName(), builder.reflectionClassName());
             assertEquals(DEFAULT.shutdownTimeout(), builder.shutdownTimeout());
+            assertEquals(DEFAULT.keyedSubscription(), builder.keyedSubscription());
         });
     }
     
@@ -42,7 +43,8 @@ public interface MetalogConfigTests {
                 .keyedQueueLimit(DEFAULT.keyedQueueLimit()+1)
                 .unkeyedThreadCount(DEFAULT.unkeyedThreadCount()+1)
                 .reflectionClassName("MyReflectionClassName")
-                .shutdownTimeout(DEFAULT.shutdownTimeout().plus(Duration.ofSeconds(1)));
+                .shutdownTimeout(DEFAULT.shutdownTimeout().plus(Duration.ofSeconds(1)))
+                .keyedSubscription(!DEFAULT.keyedSubscription());
             
             assertEquals(!DEFAULT.useReflection(), builder.useReflection());
             assertEquals(!DEFAULT.useServiceLoader(), builder.useServiceLoader());
@@ -53,6 +55,7 @@ public interface MetalogConfigTests {
             assertEquals(DEFAULT.unkeyedThreadCount()+1, builder.unkeyedThreadCount());
             assertEquals("MyReflectionClassName", builder.reflectionClassName());
             assertEquals(DEFAULT.shutdownTimeout().plus(Duration.ofSeconds(1)), builder.shutdownTimeout());
+            assertEquals(!DEFAULT.keyedSubscription(), builder.keyedSubscription());
         });
     }
 }

--- a/metalog-test/src/main/java/io/github/jonloucks/metalog/test/MetalogTests.java
+++ b/metalog-test/src/main/java/io/github/jonloucks/metalog/test/MetalogTests.java
@@ -16,10 +16,11 @@ import java.util.function.Predicate;
 
 import static io.github.jonloucks.contracts.test.Tools.*;
 import static io.github.jonloucks.metalog.api.GlobalMetalog.createMetalog;
+import static io.github.jonloucks.metalog.api.Outcome.CONSUMED;
+import static io.github.jonloucks.metalog.api.Outcome.REJECTED;
 import static io.github.jonloucks.metalog.test.MetalogTests.MetalogTestsTools.runWithScenario;
 import static io.github.jonloucks.metalog.test.Tools.*;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @SuppressWarnings("ALL")
@@ -29,7 +30,6 @@ public interface MetalogTests {
     
     @Test
     default void metalog_addFilter_WithNull_Throws() {
-
         runWithScenario(metalog -> {
             final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
                 //noinspection resource
@@ -119,6 +119,28 @@ public interface MetalogTests {
     }
     
     @Test
+    default void metalog_LoggingWhileDispatching() {
+ 
+        
+        runWithScenario(metalog -> {
+            final Subscriber subscriber = (Log log, Meta meta) -> {
+                if ("trigger".equals(log.get())) {
+                    metalog.publish(() -> "reentrant", b -> b.block());
+                    return CONSUMED;
+                }
+                return REJECTED;
+            };
+            
+            try (AutoClose closeSubscriber = metalog.subscribe(subscriber)) {
+                final AutoClose ignored = closeSubscriber;
+                
+                final Outcome outcome = metalog.publish(() -> "trigger", b -> b.block());
+                assertEquals(CONSUMED, outcome);
+            }
+        });
+    }
+    
+    @Test
     default void metalog_WhenConsoleFails() {
         withContracts(cc -> {
             
@@ -184,7 +206,7 @@ public interface MetalogTests {
                 final Metalog metalog = createMetalog(config);
                 final Subscriber subscriber = (l, m) -> {
                     sleep(Duration.ofMillis(10));
-                    return Outcome.CONSUMED;
+                    return CONSUMED;
                 };
                 final Subscriber skippedSubscriber = new Subscriber() {
                     @Override

--- a/metalog-test/src/main/java/io/github/jonloucks/metalog/test/Tests.java
+++ b/metalog-test/src/main/java/io/github/jonloucks/metalog/test/Tests.java
@@ -10,6 +10,7 @@ public interface Tests extends
     ExceptionTests,
     GlobalMetalogTests,
     KeyedDispatcherTests,
+    KeyedSubscriptionTests,
     UnkeyedDispatcherTests,
     MetaTests,
     MetalogTests,

--- a/metalog-test/src/main/java/module-info.java
+++ b/metalog-test/src/main/java/module-info.java
@@ -8,10 +8,6 @@ module io.github.jonloucks.metalog.test {
     requires transitive io.github.jonloucks.concurrency.api;
     requires transitive io.github.jonloucks.concurrency.test;
     
-    requires org.junit.jupiter.api;
-    requires org.mockito.junit.jupiter;
-    requires org.mockito;
-    
     opens io.github.jonloucks.metalog.test to org.junit.platform.commons;
     exports io.github.jonloucks.metalog.test;
 }


### PR DESCRIPTION
# Fixes #38, Only create channel threads if a subscriber is interested.

## Description

Fixes #38, Only create channel threads if a subscriber is interested.

Added a new interface MainDispatcher which is responsible for determine when a delegate dispatcher needs be created or destroyed

This is an opt-in feature via Metalog.Config.keyedSubscription(true)

In the future, the default will be enabled by default, however that would be considered a breaking change

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code improvement or restructuring without changing external behavior)
- [ ] Documentation update
- [ ] Chore (e.g., dependency updates, build tooling changes)

## How Has This Been Tested?

[Describe the testing you have performed to ensure the changes work as expected. Include details about:
Added new unit tests
All tests pass

## Checklist:

- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (if necessary).
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Additional Notes
